### PR TITLE
Added JVM debug options to the GSCs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,13 +33,16 @@ ARG DEPENDENCIES="\
 ARG CLASSPATH_XAP=/opt/gigaspaces/lib/platform/ext
 ARG CLASSPATH_PU=/opt/gigaspaces/lib/optional/pu-common
 ARG GS_TOOLS_DIR=/opt/gigaspaces/tools
+ARG GS_CONF_DIR=/opt/gigaspaces/config/gsa
 
 RUN set -ex \
     && mkdir -p \
         "${GS_TOOLS_DIR}" \
         "${CLASSPATH_XAP}" \
+        "${GS_CONF_DIR}" \
         "${CLASSPATH_PU}"
 
+COPY ./conf/* ${GS_CONF_DIR}/
 COPY ./lib-ext/* ${CLASSPATH_XAP}/
 
 COPY --from=BUILD /tmp/xap-application-deployer/target/xap-application-deployer-*.jar "${GS_TOOLS_DIR}/xap-application-deployer.jar"
@@ -59,6 +62,7 @@ RUN set -ex \
 VOLUME ["${GS_TOOLS_DIR}"]
 VOLUME ["${CLASSPATH_XAP}"]
 VOLUME ["${CLASSPATH_PU}"]
+VOLUME ["${GS_CONF_DIR}"]
 
 RUN mkdir -p /usr/local/
 
@@ -81,4 +85,5 @@ RUN mkdir -p "${YOURKIT_HOME_DIR}" \
   && unzip /tmp/YourKit-JavaProfiler.zip -d /tmp \
   && mv /tmp/YourKit-JavaProfiler-*/* "${YOURKIT_HOME_DIR}/" \
   && rm -rf /tmp/YourKit-*
-EXPOSE 10001-10009
+EXPOSE 10001-10009 20000-20001
+CMD ["host", "run-agent", "--auto", "--custom", "gsc_1=1", "--custom", "gsc_2=1"]

--- a/conf/gsc_1.xml
+++ b/conf/gsc_1.xml
@@ -1,0 +1,12 @@
+<process initial-instances="script" shutdown-class="com.gigaspaces.grid.gsa.GigaSpacesShutdownProcessHandler" restart-on-exit="always">
+    <script enable="true" work-dir="${com.gs.home}/bin"
+            windows="${com.gs.home}\bin\gs.bat" unix="${com.gs.home}/bin/gs.sh">
+        <argument>services=GSC</argument>
+        <environment name="XAP_COMPONENT_OPTIONS">${XAP_GSC_OPTIONS} -agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=20000</environment>
+    </script>
+    <vm enable="true" work-dir="${com.gs.home}/bin" main-class="com.gigaspaces.start.SystemBoot">
+        <input-argument></input-argument>
+        <argument>services=GSC</argument>
+    </vm>
+    <restart-regex>.*java\.lang\.OutOfMemoryError.*</restart-regex>
+</process>

--- a/conf/gsc_2.xml
+++ b/conf/gsc_2.xml
@@ -1,0 +1,12 @@
+<process initial-instances="script" shutdown-class="com.gigaspaces.grid.gsa.GigaSpacesShutdownProcessHandler" restart-on-exit="always">
+    <script enable="true" work-dir="${com.gs.home}/bin"
+            windows="${com.gs.home}\bin\gs.bat" unix="${com.gs.home}/bin/gs.sh">
+        <argument>services=GSC</argument>
+        <environment name="XAP_COMPONENT_OPTIONS">${XAP_GSC_OPTIONS} -agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=20001</environment>
+    </script>
+    <vm enable="true" work-dir="${com.gs.home}/bin" main-class="com.gigaspaces.start.SystemBoot">
+        <input-argument></input-argument>
+        <argument>services=GSC</argument>
+    </vm>
+    <restart-regex>.*java\.lang\.OutOfMemoryError.*</restart-regex>
+</process>


### PR DESCRIPTION
This PR adds two files named `gsc_1.xml` and `gsc_2.xml` to `XAP_HOME/config/gsa`, and modifies the startup options to run these two GSC configs instead of the default ones.

Debug ports are 20000 and 20001.